### PR TITLE
Add custom domain CNAME for GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+penalcode.unscripted.gg


### PR DESCRIPTION
## Summary
- add `CNAME` pointing to penalcode.unscripted.gg so the site retains its custom domain on deployments

## Testing
- `npm test` *(fails: Missing script "test")*
- `dig +short penalcode.unscripted.gg CNAME`

------
https://chatgpt.com/codex/tasks/task_b_6899e22046c483219123d40fd4b236c0